### PR TITLE
Fix too long url issue by using a cvs instead of Array

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Guzzle client to connect to the PeoplePerHour.com API.
 Installation Using Composer
 ===========================
 
-The client has not been added to packagist but can be included in your project using [Composer](http://getcomposer.org/) if you app the github repo.
+The client has not been added to packagist but can be included in your project using [Composer](http://getcomposer.org/) if you add the github repo.
 
 1. First you will need to add "peopleperhour/pph-php-client" as a dependency in your composer.json file:
 
@@ -36,7 +36,7 @@ The client has not been added to packagist but can be included in your project u
     php composer.phar update
     ```
 
-4. Lastly, you need to include the Composer autoloader in your bootstrap:
+4. Lastly, you need to include the Composer autoloader in your apps bootstrap code:
 
     ```php
     require '[/path/to/vendor]/autoload.php';

--- a/src/PPHApi.php
+++ b/src/PPHApi.php
@@ -268,12 +268,24 @@ class PPHApi extends GuzzleHttp\Command\Guzzle\GuzzleClient
                             'type'     => 'array',
                             'required' => false,
                             'location' => 'query',
+                            'filters' => [
+                                [
+                                    'method'=> "PPHApi::compressArrayToString",
+                                    'args'=> [ '@value' ]
+                                ]
+                            ],
                         ],
                         'f[exclude_owners]' => [
                             "description" => "Do not include hourlies from these owners in the results",
                             'type'     => 'array',
                             'required' => false,
                             'location' => 'query',
+                            'filters' => [
+                                [
+                                    'method'=> "PPHApi::compressArrayToString",
+                                    'args'=> [ '@value' ]
+                                ]
+                            ],
                         ],
                         'f[has_cover_image]' => [
                             "description" => "Ensure all results have a image or video",
@@ -306,5 +318,22 @@ class PPHApi extends GuzzleHttp\Command\Guzzle\GuzzleClient
                 ]
             ]
         ]);
+    }
+
+    /**
+     * Use a more compressed method of requesting multiple IDs.
+     *
+     * i.e. Instead of using Array format:
+     *  f[myvar][0]=123&f[myvar][1]=1234&f[myvar][2]=12345
+     * Use string format:
+     *  f[myvar]=123,1234,12345
+     * Otherwise API call gets too big when Array has lots of items.
+     *
+     * @param Array $value Input Array
+     * @return String
+     */
+    public static function compressArrayToString($value)
+    {
+        return join(',',$value);
     }
 }


### PR DESCRIPTION
Mailchap issue - API URL is too long, need to change format to `f[exclude_hourlies]=1,2,3,4`
