### PR TITLE
Resolve dependence with guzzle-services

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
     ],
     "require": {
         "php": ">=5.4",
-        "guzzlehttp/guzzle-services": "0.3.*@dev"
+        "guzzlehttp/guzzle-services": "0.3.*@dev",
+        "guzzlehttp/command": "0.6.*"
     },
     "suggest": {
         "doctrine/cache": "Adds support for caching of credentials and responses"


### PR DESCRIPTION
After a composer update we were seeing these errors:

> PHP Fatal error:  Class GuzzleHttp\Command\Guzzle\GuzzleClient contains 1 abstract method and must therefore be declared abstract or implement the remaining methods (GuzzleHttp\Command\AbstractClient::serializeRequest) in /var/www/mailchap/vendor/guzzlehttp/guzzle-services/src/GuzzleClient.php on line 144

The issue is with `guzzle-services` and filed here: https://github.com/guzzle/guzzle-services/issues/50

The workaround for the moment recommended by @mtdowling in https://github.com/guzzle/guzzle-services/issues/50#issuecomment-58906326 is:

> Use. 0.6 until it's updated.
